### PR TITLE
Replace jpg file names with png ones in chessboard_timing_list.dat

### DIFF
--- a/testdata/cv/cameracalibration/chessboard_timing_list.dat
+++ b/testdata/cv/cameracalibration/chessboard_timing_list.dat
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 <opencv_storage>
 <boards>
-"chess3.jpg" 1 5 7
-"chess1.jpg" 1 5 7
-"../shared/baboon.jpg" 0 6 8
+"chess3.png" 1 5 7
+"chess1.png" 1 5 7
+"../shared/baboon.png" 0 6 8
 "../shared/box_in_scene.png" 0 5 7
-"../shared/airplane.jpg" 0 5 7
-"chessboard-artificial2.jpg" 1 5 11
-"chessboard-artificial1.jpg" 1 5 13
-"chess2.jpg" 1 5 7
-"chess4.jpg" 1 5 7
-"chess5.jpg" 1 5 7
-"chess6.jpg" 1 5 7
-"chess7.jpg" 1 5 7
-"chess8.jpg" 1 4 6
-"chess9.jpg" 1 19 21
-"small_chessboard1.jpg" 1 3 4
-"small_chessboard2.jpg" 1 3 4
-"small_chessboard3.jpg" 1 3 4
+"../shared/airplane.png" 0 5 7
+"chessboard-artificial2.png" 1 5 11
+"chessboard-artificial1.png" 1 5 13
+"chess2.png" 1 5 7
+"chess4.png" 1 5 7
+"chess5.png" 1 5 7
+"chess6.png" 1 5 7
+"chess7.png" 1 5 7
+"chess8.png" 1 4 6
+"chess9.png" 1 19 21
+"small_chessboard1.png" 1 3 4
+"small_chessboard2.png" 1 3 4
+"small_chessboard3.png" 1 3 4
 "../shared/box.png" 0 6 8
-"../shared/fruits.jpg" 0 5 7
+"../shared/fruits.png" 0 5 7
 </boards></opencv_storage>


### PR DESCRIPTION
The referenced JPEG images haven't existed since forever. This hasn't been detected before, because the test that uses this list silently skips images that aren't found.

`chessboard-artificial[12].jpg` do still exist, but it's better to use the PNG versions anyway, to avoid decoding variations.
